### PR TITLE
added new command line flags for max_months and my name

### DIFF
--- a/clbme
+++ b/clbme
@@ -8,7 +8,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six
 import argparse
 
-from pybtex.database import parse_file
+from pybtex.database import parse_file,Person
+
+from datetime import date
+import sys
 
 from collabme.util import custom_argparse_types as cats
 from collabme import name
@@ -20,23 +23,47 @@ def parse_args(arg_list=None):
     parser.add_argument('-b', '--bibtex', 
             type=cats.abs_existing_file,
             help='A bibtex file to collect collaborators from.')
-    
+    parser.add_argument('-m', '--max_months', 
+            type=int,
+            help='Limit time interval to go back to (e.g., NSF: 48 months)')
+    parser.add_argument('-n', '--name',
+            help='Your name to find your co-authors')
     #volume = parser.add_mutually_exclusive_group()
     #volume.add_argument("-v", "--verbose", help="Increase the output verbosity", action="store_true")
     #volume.add_argument("-q", "--quiet",   help="Run silently",                  action="store_true")
 
     return parser.parse_args(arg_list)
 
-
 def main(args):
     bib = parse_file(args.bibtex)
-  
+    year = date.today().year  
+
+    me = Person(args.name)
+
     #NOTE: using a dict here ensures uniqueness of full names
     all_people = {}
     for key, entry in six.iteritems(bib.entries):
-        for person in entry.persons['author']:
-            all_people[name.full(person)] = person
-            
+        #first, make sure that we are a co-author with these people
+        #There must be a more efficient way than this
+        flag = False
+        
+        #wrap this into a try except, in case your bib file contains
+        #entries with no authors (e.g. monitored folders do that)
+        try:
+            for person in entry.persons.values()[0]:
+                if me.last_names == person.last_names:
+                    flag = True
+        except IndexError:
+            continue         
+
+        #if our name is in the list of authors for that paper
+        #add the co-authors to the output list
+        if flag:
+            #do that only for the minimum number of months required
+            if ((year - int(entry.fields['year'][:4]))*12 <= args.max_months):
+                for person in entry.persons['author']:
+                    all_people[name.full(person)] = person
+
     #NOTE: Sort by last name
     for person in sorted(all_people.values(), key=name.sort_on_last):
         full_name = name.full(person)


### PR DESCRIPTION
Not pretty, but works. Command line flags aren't optional, though, that
may be a nice touch-up.

max_months allows setting of a time limit within which we
count co-authors as collaborators

name let's me set myself, so my single huge bib file
that contains all references I've read, and includes
my papers, can be used for this.